### PR TITLE
fix: npmjs brand guidline url

### DIFF
--- a/_data/simple-icons.json
+++ b/_data/simple-icons.json
@@ -8490,7 +8490,7 @@
             "title": "npm",
             "hex": "CB3837",
             "source": "https://www.npmjs.com",
-            "guidelines": "https://www.npmjs.com/policies/trademark"
+            "guidelines": "https://docs.npmjs.com/policies/logos-and-usage"
         },
         {
             "title": "Nrwl",


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines:
https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md

Consider adding a preview image of your submission using:
https://petershaggynoble.github.io/SI-Sandbox/preview/
-->

**Issue:** closes #

**Similarweb rank:**
  <!-- The Similarweb rank can be retrieved at https://www.similarweb.com
       Please see our contributing guidelines for more details on how we
       assess a brand's popularity. -->

### Checklist
  - [x] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
The brand guideline for npm lead to a 404.
